### PR TITLE
Use more precise exception type in method declaration.

### DIFF
--- a/src/main/java/org/eclipse/iot/unide/ppmp/PPMPPackager.java
+++ b/src/main/java/org/eclipse/iot/unide/ppmp/PPMPPackager.java
@@ -34,7 +34,7 @@ public class PPMPPackager {
         mapper.setSerializationInclusion(Include.NON_NULL);
     }
 
-    public String getMessage(Object jsonBean) throws IOException {
+    public String getMessage(Object jsonBean) throws JsonProcessingException {
         String json = mapper.writeValueAsString(jsonBean);
         return json;
     }


### PR DESCRIPTION
It simple makes no sense if catch-expression has to change if client code switches from getMessage(Object jsonBean, boolean indentOutput) to getMessage(Object jsonBean).